### PR TITLE
fix bugs about error message

### DIFF
--- a/lib/generic-http.js
+++ b/lib/generic-http.js
@@ -68,7 +68,7 @@ HTTP.prototype.request = function(cb){
                 });
     }
     else {
-      return cb({error:e.message, options: args.options});
+      return cb({error:e, options: self.req.options});
     }
   });
   var body = this.req.body;

--- a/lib/generic-http.js
+++ b/lib/generic-http.js
@@ -42,6 +42,7 @@ HTTP.prototype.createRequest = function(method, path, headers, body) {
 }
 
 HTTP.prototype.request = function(cb){
+  var self = this;
   var req = http.request(this.req.options, function(res){
     res.setEncoding('utf8');
     if(!resultCodeTable[res.statusCode]){
@@ -61,7 +62,14 @@ HTTP.prototype.request = function(cb){
     });
   });
   req.on('error', function(e){
-    return cb({error:e.message, options: args.options});
+    if(e.code === 'ENOTFOUND'){
+      return cb({error:'Internet Connection Lost'
+                ,reason: 'DNS Not Found, Please check the internet connection'
+                });
+    }
+    else {
+      return cb({error:e.message, options: args.options});
+    }
   });
   var body = this.req.body;
   if(body){


### PR DESCRIPTION
this patch fixes bugs about logging errors when requests a HTTP calls to the ThingPlug API server.
After this patch is accepted, detailed error stack is logged to stdout.
Furthermore, it checks additional information if the network connection fails to reach the internet.
(DNS lookup errors or outbound connection to internet is blocked...)
